### PR TITLE
Fix ebs 1

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,5 +1,5 @@
 {
-    "AWSEBDockerrunVersion": 2,
+    "AWSEBDockerrunVersion": 3,
     "containerDefinitions": [
         {
             "name": "api",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -6,12 +6,6 @@
             "image": "happyleader/imposc-service",
             "hostname": "api",
             "essential": false,
-            "portMappings": [
-                {
-                    "hostPort": 5000,
-                    "containerPort": 5000
-                }
-            ],
             "memory": 128
         },
         {


### PR DESCRIPTION
Apparently the dockerrun version now has to be 3, not 2, for a multi-container app 